### PR TITLE
Detect new code smells

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Configure it in `package.json`.
       "ramda"
     ],
     "rules": {
+      "ramda/always-simplification": "error",
       "ramda/any-pass-simplification": "error",
       "ramda/both-simplification": "error",
       "ramda/complement-simplification": "error",
@@ -54,6 +55,7 @@ Configure it in `package.json`.
 
 ## Rules
 
+- `always-simplification` - Detects when `always` usage can be replaced by a Ramda function
 - `any-pass-simplification` - Suggests simplifying list of negations in `anyPass` by single negation in `allPass`
 - `both-simplification` - Suggests transforming negated `both` conditions on negated `either`
 - `complement-simplification` - Forbids confusing `complement`, suggesting a better one

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Configure it in `package.json`.
       "ramda/any-pass-simplification": "error",
       "ramda/both-simplification": "error",
       "ramda/complement-simplification": "error",
+      "ramda/compose-simplification": "error",
       "ramda/cond-simplification": "error",
       "ramda/either-simplification": "error",
       "ramda/filter-simplification": "error",
@@ -41,6 +42,7 @@ Configure it in `package.json`.
       "ramda/no-redundant-and": "error",
       "ramda/no-redundant-not": "error",
       "ramda/no-redundant-or": "error",
+      "ramda/pipe-simplification": "error",
       "ramda/prefer-ramda-boolean": "error",
       "ramda/prop-satisfies-simplification": "error",
       "ramda/reduce-simplification": "error",
@@ -59,6 +61,7 @@ Configure it in `package.json`.
 - `any-pass-simplification` - Suggests simplifying list of negations in `anyPass` by single negation in `allPass`
 - `both-simplification` - Suggests transforming negated `both` conditions on negated `either`
 - `complement-simplification` - Forbids confusing `complement`, suggesting a better one
+- `compose-simplification` - Detects when a function that has the same behavior already exists
 - `cond-simplification` - Forbids using `cond` when `ifElse`, `either` or `both` fits
 - `either-simplification` - Suggests transforming negated `either` conditions on negated `both`
 - `filter-simplification` - Forbids using negated `filter` and suggests `reject`
@@ -68,6 +71,7 @@ Configure it in `package.json`.
 - `no-redundant-and` - Forbids `and` with 2 parameters in favor of `&&`
 - `no-redundant-not` - Forbids `not` with 1 parameter in favor of `!`
 - `no-redundant-or` - Forbids `or` with 2 parameters in favor of `||`
+- `pipe-simplification` - Detects when a function that has the same behavior already exists
 - `prefer-ramda-boolean` - Enforces using `R.T` and `R.F` instead of explicit functions
 - `prop-satisfies-simplification` - Detects when can replace `propSatisfies` by more simple functions
 - `reduce-simplification` - Detects when can replace `reduce` by `sum` or `product`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Configure it in `package.json`.
       "ramda/no-redundant-and": "error",
       "ramda/no-redundant-not": "error",
       "ramda/no-redundant-or": "error",
+      "ramda/prefer-ramda-boolean": "error",
       "ramda/prop-satisfies-simplification": "error",
       "ramda/reduce-simplification": "error",
       "ramda/reject-simplification": "error",
@@ -65,6 +66,7 @@ Configure it in `package.json`.
 - `no-redundant-and` - Forbids `and` with 2 parameters in favor of `&&`
 - `no-redundant-not` - Forbids `not` with 1 parameter in favor of `!`
 - `no-redundant-or` - Forbids `or` with 2 parameters in favor of `||`
+- `prefer-ramda-boolean` - Enforces using `R.T` and `R.F` instead of explicit functions
 - `prop-satisfies-simplification` - Detects when can replace `propSatisfies` by more simple functions
 - `reduce-simplification` - Detects when can replace `reduce` by `sum` or `product`
 - `reject-simplification` - Forbids using negated `reject` and suggests `filter`

--- a/ast-helper.js
+++ b/ast-helper.js
@@ -33,6 +33,13 @@ const isCalling = pattern => R.where({
     arguments: pattern.arguments || R.T
 });
 
+// :: Node -> Boolean
+const isBooleanLiteral = R.both(
+    R.propEq('type', 'Literal'),
+    R.propSatisfies(R.is(Boolean), 'value')
+);
+
 exports.isRamdaMethod = isRamdaMethod;
 exports.isCalling = isCalling;
 exports.getName = getName;
+exports.isBooleanLiteral = isBooleanLiteral;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ramda",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ESLint rules for use with Ramda",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ramda",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "ESLint rules for use with Ramda",
   "license": "MIT",
   "keywords": [

--- a/rules/always-simplification.js
+++ b/rules/always-simplification.js
@@ -6,7 +6,10 @@ const isCalling = ast.isCalling;
 const isBooleanLiteral = ast.isBooleanLiteral;
 
 const report = (instead, prefer) => `\`always(${instead})\` should be simplified to \`${prefer}\``;
-const getAlternative = R.applyTo(R.__, R.compose(R.toUpper, R.head, R.toString));
+const alternatives = {
+    'true': 'T',
+    'false': 'F'
+};
 
 const create = context => ({
     CallExpression(node) {
@@ -25,7 +28,7 @@ const create = context => ({
 
             context.report({
                 node,
-                message: report(instead, getAlternative(instead))
+                message: report(instead, alternatives[instead])
             });
         }
     }

--- a/rules/always-simplification.js
+++ b/rules/always-simplification.js
@@ -39,7 +39,7 @@ module.exports = {
     meta: {
         docs: {
             description: 'Detects cases where `always` is redundant',
-            recommended: 'error'
+            recommended: 'off'
         }
     }
 };

--- a/rules/always-simplification.js
+++ b/rules/always-simplification.js
@@ -1,0 +1,42 @@
+'use strict';
+const R = require('ramda');
+const ast = require('../ast-helper');
+
+const isCalling = ast.isCalling;
+const isBooleanLiteral = ast.isBooleanLiteral;
+
+const report = (instead, prefer) => `\`always(${instead})\` should be simplified to \`${prefer}\``;
+const getAlternative = R.applyTo(R.__, R.compose(R.toUpper, R.head, R.toString));
+
+const create = context => ({
+    CallExpression(node) {
+        const match = isCalling({
+            name: 'always',
+            arguments: R.both(
+                R.propEq('length', 1),
+                R.where({
+                    0: isBooleanLiteral
+                })
+            )
+        });
+
+        if (match(node)) {
+            const instead = node.arguments[0].value;
+
+            context.report({
+                node,
+                message: report(instead, getAlternative(instead))
+            });
+        }
+    }
+});
+
+module.exports = {
+    create,
+    meta: {
+        docs: {
+            description: 'Detects cases where `always` is redundant',
+            recommended: 'error'
+        }
+    }
+};

--- a/rules/compose-simplification.js
+++ b/rules/compose-simplification.js
@@ -1,0 +1,38 @@
+'use strict';
+const R = require('ramda');
+const ast = require('../ast-helper');
+
+const isCalling = ast.isCalling;
+const isRamdaMethod = ast.isRamdaMethod;
+
+const create = context => ({
+    CallExpression(node) {
+        const match = isCalling({
+            name: 'compose',
+            arguments: R.both(
+                R.propSatisfies(R.lte(2), 'length'),
+                R.where({
+                    0: isRamdaMethod('flatten'),
+                    1: isRamdaMethod('map')
+                })
+            )
+        });
+
+        if (match(node)) {
+            context.report({
+                node,
+                message: '`compose(flatten, map)` should be simplified to `chain`'
+            });
+        }
+    }
+});
+
+module.exports = {
+    create,
+    meta: {
+        docs: {
+            description: 'Detects when there are better functions that behave the same as `compose`',
+            recommended: 'error'
+        }
+    }
+};

--- a/rules/compose-simplification.js
+++ b/rules/compose-simplification.js
@@ -32,7 +32,7 @@ module.exports = {
     meta: {
         docs: {
             description: 'Detects when there are better functions that behave the same as `compose`',
-            recommended: 'error'
+            recommended: 'off'
         }
     }
 };

--- a/rules/pipe-simplification.js
+++ b/rules/pipe-simplification.js
@@ -1,0 +1,38 @@
+'use strict';
+const R = require('ramda');
+const ast = require('../ast-helper');
+
+const isCalling = ast.isCalling;
+const isRamdaMethod = ast.isRamdaMethod;
+
+const create = context => ({
+    CallExpression(node) {
+        const match = isCalling({
+            name: 'pipe',
+            arguments: R.both(
+                R.propSatisfies(R.lte(2), 'length'),
+                R.where({
+                    0: isRamdaMethod('map'),
+                    1: isRamdaMethod('flatten')
+                })
+            )
+        });
+
+        if (match(node)) {
+            context.report({
+                node,
+                message: '`pipe(map, flatten)` should be simplified to `chain`'
+            });
+        }
+    }
+});
+
+module.exports = {
+    create,
+    meta: {
+        docs: {
+            description: 'Detects when there are better functions that behave the same as `pipe`',
+            recommended: 'error'
+        }
+    }
+};

--- a/rules/pipe-simplification.js
+++ b/rules/pipe-simplification.js
@@ -32,7 +32,7 @@ module.exports = {
     meta: {
         docs: {
             description: 'Detects when there are better functions that behave the same as `pipe`',
-            recommended: 'error'
+            recommended: 'off'
         }
     }
 };

--- a/rules/prefer-ramda-boolean.js
+++ b/rules/prefer-ramda-boolean.js
@@ -1,0 +1,54 @@
+'use strict';
+const R = require('ramda');
+
+const report = (instead, prefer) => `Instead of \`() => ${instead}\`, prefer \`${prefer}\``;
+const isBooleanLiteral = R.both(
+    R.propEq('type', 'Literal'),
+    R.propSatisfies(R.is(Boolean), 'value')
+);
+const getAlternative = R.applyTo(R.__, R.compose(R.toUpper, R.head, R.toString));
+
+const create = context => ({
+    ArrowFunctionExpression(node) {
+        if (isBooleanLiteral(node.body)) {
+            const instead = node.body.value;
+            context.report({
+                node,
+                message: report(instead, getAlternative(instead))
+            });
+        }
+    },
+
+    FunctionExpression(node) {
+        const onlyReturnsBoolean = R.where({
+            type: R.equals('BlockStatement'),
+            body: R.both(
+                R.propEq('length', 1),
+                R.where({
+                    0: R.where({
+                        type: R.equals('ReturnStatement'),
+                        argument: isBooleanLiteral
+                    })
+                })
+            )
+        });
+
+        if (onlyReturnsBoolean(node.body)) {
+            const instead = node.body.body[0].argument.value;
+            context.report({
+                node,
+                message: report(instead, getAlternative(instead))
+            });
+        }
+    }
+});
+
+module.exports = {
+    create,
+    meta: {
+        docs: {
+            description: 'Suggests using Ramda T and F functions instead of explicit versions',
+            recommended: 'error'
+        }
+    }
+};

--- a/test/always-simplification.js
+++ b/test/always-simplification.js
@@ -1,0 +1,35 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/always-simplification';
+
+const ruleTester = avaRuleTester(test, {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        sourceType: 'module'
+    }
+});
+
+const error = (from, to) => ({
+    ruleId: 'always-simplification',
+    message: `\`always(${from})\` should be simplified to \`${to}\``
+});
+
+ruleTester.run('always-simplification', rule, {
+    valid: [
+        'always',
+        'always(1)',
+        'always(always)'
+    ],
+    invalid: [
+        {
+            code: 'always(true)',
+            errors: [error('true', 'T')]
+        },
+        {
+            code: 'always(false)',
+            errors: [error('false', 'F')]
+        }
+    ]
+});

--- a/test/compose-simplification.js
+++ b/test/compose-simplification.js
@@ -1,0 +1,37 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/compose-simplification';
+
+const ruleTester = avaRuleTester(test, {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        sourceType: 'module'
+    }
+});
+
+const error = {
+    chain: {
+        ruleId: 'compose-simplification',
+        message: '`compose(flatten, map)` should be simplified to `chain`'
+    }
+};
+
+ruleTester.run('compose-simplification', rule, {
+    valid: [
+        'compose(map, flatten)',
+        'compose()',
+        'compose(left, right)'
+    ],
+    invalid: [
+        {
+            code: 'compose(flatten, map)',
+            errors: [error.chain]
+        },
+        {
+            code: 'R[\'compose\'](R.flatten, map)',
+            errors: [error.chain]
+        }
+    ]
+});

--- a/test/map-simplification.js
+++ b/test/map-simplification.js
@@ -12,8 +12,14 @@ const ruleTester = avaRuleTester(test, {
 });
 
 const error = {
-    ruleId: 'map-simplification',
-    message: '`map(prop(_))` should be simplified to `pluck(_)`'
+    prop: {
+        ruleId: 'map-simplification',
+        message: '`map(prop(_))` should be simplified to `pluck(_)`'
+    },
+    project: {
+        ruleId: 'map-simplification',
+        message: '`map(pickAll(_))` should be simplified to `project(_)`'
+    }
 };
 
 ruleTester.run('map-simplification', rule, {
@@ -21,20 +27,33 @@ ruleTester.run('map-simplification', rule, {
         'map(transformer, list)',
         'map(doubleMe, [1, 2, 3])',
         'R.map(transformer, list)',
-        'R.map(R.inc, [1, 2, 3])'
+        'R.map(R.inc, [1, 2, 3])',
+        'project([\'name\', \'age\'])'
     ],
     invalid: [
         {
             code: 'map(prop(\'name\'))',
-            errors: [error]
+            errors: [error.prop]
         },
         {
             code: 'R.map(R.prop(\'name\'))',
-            errors: [error]
+            errors: [error.prop]
         },
         {
             code: 'map(R.prop(\'name\'))',
-            errors: [error]
+            errors: [error.prop]
+        },
+        {
+            code: 'map(R.pickAll(values))',
+            errors: [error.project]
+        },
+        {
+            code: 'R.map(R.pickAll([]))',
+            errors: [error.project]
+        },
+        {
+            code: 'R[\'map\'](pickAll([]))',
+            errors: [error.project]
         }
     ]
 });

--- a/test/pipe-simplification.js
+++ b/test/pipe-simplification.js
@@ -1,0 +1,37 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/pipe-simplification';
+
+const ruleTester = avaRuleTester(test, {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        sourceType: 'module'
+    }
+});
+
+const error = {
+    chain: {
+        ruleId: 'pipe-simplification',
+        message: '`pipe(map, flatten)` should be simplified to `chain`'
+    }
+};
+
+ruleTester.run('pipe-simplification', rule, {
+    valid: [
+        'pipe(flatten, map)',
+        'pipe()',
+        'pipe(left, right)'
+    ],
+    invalid: [
+        {
+            code: 'pipe(map, flatten)',
+            errors: [error.chain]
+        },
+        {
+            code: 'R[\'pipe\'](R.map, flatten)',
+            errors: [error.chain]
+        }
+    ]
+});

--- a/test/prefer-ramda-boolean.js
+++ b/test/prefer-ramda-boolean.js
@@ -21,7 +21,12 @@ ruleTester.run('prefer-ramda-boolean', rule, {
         'true',
         'R.T',
         'R.F',
-        '() => computation'
+        '() => computation',
+        '() => { return 1; }',
+        '(function () { return 1; })',
+        '(function() { return; })',
+        '() => {}',
+        '() => { return; }'
     ],
     invalid: [
         {
@@ -39,6 +44,14 @@ ruleTester.run('prefer-ramda-boolean', rule, {
         {
             code: '() => true',
             errors: [error('true', 'T')]
+        },
+        {
+            code: '() => { return true; }',
+            errors: [error('true', 'T')]
+        },
+        {
+            code: '() => { return false; }',
+            errors: [error('false', 'F')]
         }
     ]
 });

--- a/test/prefer-ramda-boolean.js
+++ b/test/prefer-ramda-boolean.js
@@ -1,0 +1,44 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-ramda-boolean';
+
+const ruleTester = avaRuleTester(test, {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        sourceType: 'module'
+    }
+});
+
+const error = (instead, prefer) => ({
+    ruleId: 'prefer-ramda-boolean',
+    message: `Instead of \`() => ${instead}\`, prefer \`${prefer}\``
+});
+
+ruleTester.run('prefer-ramda-boolean', rule, {
+    valid: [
+        'true',
+        'R.T',
+        'R.F',
+        '() => computation'
+    ],
+    invalid: [
+        {
+            code: '(function () { return false; })',
+            errors: [error('false', 'F')]
+        },
+        {
+            code: '(function () { return true; })',
+            errors: [error('true', 'T')]
+        },
+        {
+            code: '() => false',
+            errors: [error('false', 'F')]
+        },
+        {
+            code: '() => true',
+            errors: [error('true', 'T')]
+        }
+    ]
+});


### PR DESCRIPTION
### Add `prefer-ramda-boolean` rule

- Valid
```js
R.T
R.F
```

- Invalid
```js
function () { return true; }
() => { return true; }
() => false
```

### Add `always-simplification` rule

- Valid
```js
R.T
R.F
```

- Invalid
```js
always(true)
always(false)
```

### Add `pipe-simplification` and `compose-simplification`

Suggesting composition of `map` and `flatten` to be `chain`.

### Detects `map(pickAll(_))`

And suggests using `project`.