### PR TITLE
Add compose-pipe-style rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Configure it in `package.json`.
       "ramda/any-pass-simplification": "error",
       "ramda/both-simplification": "error",
       "ramda/complement-simplification": "error",
+      "ramda/compose-pipe-style": "error",
       "ramda/compose-simplification": "error",
       "ramda/cond-simplification": "error",
       "ramda/either-simplification": "error",
@@ -61,6 +62,7 @@ Configure it in `package.json`.
 - `any-pass-simplification` - Suggests simplifying list of negations in `anyPass` by single negation in `allPass`
 - `both-simplification` - Suggests transforming negated `both` conditions on negated `either`
 - `complement-simplification` - Forbids confusing `complement`, suggesting a better one
+- `compose-pipe-style` - Prefer `compose` for single line expression and `pipe` for multiline.
 - `compose-simplification` - Detects when a function that has the same behavior already exists
 - `cond-simplification` - Forbids using `cond` when `ifElse`, `either` or `both` fits
 - `either-simplification` - Suggests transforming negated `either` conditions on negated `both`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Configure it in `package.json`.
 - `any-pass-simplification` - Suggests simplifying list of negations in `anyPass` by single negation in `allPass`
 - `both-simplification` - Suggests transforming negated `both` conditions on negated `either`
 - `complement-simplification` - Forbids confusing `complement`, suggesting a better one
-- `compose-pipe-style` - Prefer `compose` for single line expression and `pipe` for multiline.
+- `compose-pipe-style` - Enforces `compose` for single line expression and `pipe` for multiline
 - `compose-simplification` - Detects when a function that has the same behavior already exists
 - `cond-simplification` - Forbids using `cond` when `ifElse`, `either` or `both` fits
 - `either-simplification` - Suggests transforming negated `either` conditions on negated `both`

--- a/rules/compose-pipe-style.js
+++ b/rules/compose-pipe-style.js
@@ -1,0 +1,47 @@
+'use strict';
+const R = require('ramda');
+const isCalling = require('../ast-helper').isCalling;
+
+const startLine = R.path(['loc', 'start', 'line']);
+const endLine = R.path(['loc', 'end', 'line']);
+const isSingleLine = R.converge(R.equals, [startLine, endLine]);
+
+const create = context => ({
+    CallExpression(node) {
+        const matchCompose = isCalling({
+            name: 'compose'
+        });
+
+        const matchPipe = isCalling({
+            name: 'pipe'
+        });
+
+        if (matchCompose(node)) {
+            if (!isSingleLine(node)) {
+                context.report({
+                    node,
+                    message: 'Prefer `pipe` over `compose` for multiline expression'
+                });
+            }
+        }
+
+        if (matchPipe(node)) {
+            if (isSingleLine(node)) {
+                context.report({
+                    node,
+                    message: 'Prefer `compose` over `pipe` for single line expression'
+                });
+            }
+        }
+    }
+});
+
+module.exports = {
+    create,
+    meta: {
+        docs: {
+            description: 'Prefer `compose` for single line expression and `pipe` for multiline.',
+            recommended: 'off'
+        }
+    }
+};

--- a/rules/compose-pipe-style.js
+++ b/rules/compose-pipe-style.js
@@ -16,22 +16,18 @@ const create = context => ({
             name: 'pipe'
         });
 
-        if (matchCompose(node)) {
-            if (!isSingleLine(node)) {
-                context.report({
-                    node,
-                    message: 'Prefer `pipe` over `compose` for multiline expression'
-                });
-            }
+        if (matchCompose(node) && !isSingleLine(node)) {
+            context.report({
+                node,
+                message: 'Prefer `pipe` over `compose` for multiline expression'
+            });
         }
 
-        if (matchPipe(node)) {
-            if (isSingleLine(node)) {
-                context.report({
-                    node,
-                    message: 'Prefer `compose` over `pipe` for single line expression'
-                });
-            }
+        if (matchPipe(node) && isSingleLine(node)) {
+            context.report({
+                node,
+                message: 'Prefer `compose` over `pipe` for single line expression'
+            });
         }
     }
 });

--- a/rules/compose-pipe-style.js
+++ b/rules/compose-pipe-style.js
@@ -36,7 +36,7 @@ module.exports = {
     create,
     meta: {
         docs: {
-            description: 'Prefer `compose` for single line expression and `pipe` for multiline.',
+            description: 'Enforces `compose` for single line expression and `pipe` for multiline',
             recommended: 'off'
         }
     }

--- a/test/compose-pipe-style.js
+++ b/test/compose-pipe-style.js
@@ -1,0 +1,50 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/compose-pipe-style';
+
+const ruleTester = avaRuleTester(test, {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        sourceType: 'module'
+    }
+});
+
+const error = {
+    compose: {
+        ruleId: 'compose-pipe-style',
+        message: 'Prefer `pipe` over `compose` for multiline expression'
+    },
+    pipe: {
+        ruleId: 'compose-pipe-style',
+        message: 'Prefer `compose` over `pipe` for single line expression'
+    }
+};
+
+ruleTester.run('compose-pipe-style', rule, {
+    valid: [
+        'compose(a, b, c)',
+        'R.compose(a, b, c)',
+        'pipe(\na,\nb,\nc\n)',
+        'R.pipe(\na,\nb,\nc\n)',
+    ],
+    invalid: [
+        {
+            code: 'compose(\na,\nb,\nc\n)',
+            errors: [error.compose]
+        },
+        {
+            code: 'R.compose(\na,\nb,\nc)',
+            errors: [error.compose]
+        },
+        {
+            code: 'pipe(a, b, c)',
+            errors: [error.pipe]
+        },
+        {
+            code: 'R.pipe(a, b, c)',
+            errors: [error.pipe]
+        }
+    ]
+});

--- a/test/compose-pipe-style.js
+++ b/test/compose-pipe-style.js
@@ -28,6 +28,8 @@ ruleTester.run('compose-pipe-style', rule, {
         'R.compose(a, b, c)',
         'pipe(\na,\nb,\nc\n)',
         'R.pipe(\na,\nb,\nc\n)',
+        'pipe(\na, b, c)', // not stylish but can be handled with function-paren-newline
+        'pipe(a, b, c\n)' // not stylish but can be handled with function-paren-newline
     ],
     invalid: [
         {
@@ -36,6 +38,10 @@ ruleTester.run('compose-pipe-style', rule, {
         },
         {
             code: 'R.compose(\na,\nb,\nc)',
+            errors: [error.compose]
+        },
+        {
+            code: 'compose(\na, b, c\n)',
             errors: [error.compose]
         },
         {


### PR DESCRIPTION
### Add `compose-pipe-style` rule
Enforce a style for compose and pipe: compose for single line expression, pipe for multiline. 
- Valid
```js
compose(a, b, c)
pipe(
  a,
  b,
  c
)
```
- Invalid
```js
compose(
  a,
  b,
  c
)
pipe(a, b, c)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramda/eslint-plugin-ramda/10)
<!-- Reviewable:end -->
