### PR TITLE
Add rule `eq-by-simplification`

### DIFF
--- a/rules/eq-by-simplification.js
+++ b/rules/eq-by-simplification.js
@@ -7,7 +7,7 @@ const create = context => ({
         const match = isCalling({
             name: 'eqBy',
             arguments: R.both(
-                R.propSatisfies(R.lt(0), 'length'),
+                R.complement(R.isEmpty),
                 R.propSatisfies(isCalling({
                     name: 'prop'
                 }), 0)
@@ -28,7 +28,7 @@ module.exports = {
     meta: {
         docs: {
             description: 'Detects when `eqBy(props(_))` can be replaced by `eqProps(_)`',
-            recommended: 'error'
+            recommended: 'off'
         }
     }
 };

--- a/rules/eq-by-simplification.js
+++ b/rules/eq-by-simplification.js
@@ -1,0 +1,34 @@
+'use strict';
+const R = require('ramda');
+const isCalling = require('../ast-helper').isCalling;
+
+const create = context => ({
+    CallExpression(node) {
+        const match = isCalling({
+            name: 'eqBy',
+            arguments: R.both(
+                R.propSatisfies(R.lt(0), 'length'),
+                R.propSatisfies(isCalling({
+                    name: 'prop'
+                }), 0)
+            )
+        });
+
+        if (match(node)) {
+            context.report({
+                node,
+                message: '`eqBy(prop(_))` should be simplified to `eqProps(_)`'
+            });
+        }
+    }
+});
+
+module.exports = {
+    create,
+    meta: {
+        docs: {
+            description: 'Detects when `eqBy(props(_))` can be replaced by `eqProps(_)`',
+            recommended: 'error'
+        }
+    }
+};

--- a/rules/eq-by-simplification.js
+++ b/rules/eq-by-simplification.js
@@ -9,7 +9,8 @@ const create = context => ({
             arguments: R.both(
                 R.complement(R.isEmpty),
                 R.propSatisfies(isCalling({
-                    name: 'prop'
+                    name: 'prop',
+                    arguments: R.propEq('length', 1)
                 }), 0)
             )
         });

--- a/rules/eq-by-simplification.js
+++ b/rules/eq-by-simplification.js
@@ -27,7 +27,7 @@ module.exports = {
     create,
     meta: {
         docs: {
-            description: 'Detects when `eqBy(props(_))` can be replaced by `eqProps(_)`',
+            description: 'Detects when `eqBy(prop(_))` can be replaced by `eqProps(_)`',
             recommended: 'off'
         }
     }

--- a/test/eq-by-simplification.js
+++ b/test/eq-by-simplification.js
@@ -19,7 +19,8 @@ const error = {
 ruleTester.run('filter-simplification', rule, {
     valid: [
         'eqBy(trim, \'\')',
-        'R.eqBy(R.pluck(key))'
+        'R.eqBy(R.pluck(key))',
+        'eqBy(prop(\'name\', namedObj))'
     ],
     invalid: [
         {

--- a/test/eq-by-simplification.js
+++ b/test/eq-by-simplification.js
@@ -1,0 +1,34 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/eq-by-simplification';
+
+const ruleTester = avaRuleTester(test, {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        sourceType: 'module'
+    }
+});
+
+const error = {
+    ruleId: 'eq-by-simplification',
+    message: '`eqBy(prop(_))` should be simplified to `eqProps(_)`'
+};
+
+ruleTester.run('filter-simplification', rule, {
+    valid: [
+        'eqBy(trim, \'\')',
+        'R.eqBy(R.pluck(key))'
+    ],
+    invalid: [
+        {
+            code: 'eqBy(prop(\'a\'))',
+            errors: [error]
+        },
+        {
+            code: 'R.eqBy(R.prop(\'b\'), value)',
+            errors: [error]
+        }
+    ]
+});


### PR DESCRIPTION
This pull-request adds the `eq-by-simplification` rule.

It suggests using `eqProps` instead of `eqBy(prop(_))`.