### PR TITLE
Bugfix for map and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Configure it in `package.json`.
       "ramda/compose-simplification": "error",
       "ramda/cond-simplification": "error",
       "ramda/either-simplification": "error",
+      "ramda/eq-by-simplification": "error",
       "ramda/filter-simplification": "error",
       "ramda/if-else-simplification": "error",
       "ramda/map-simplification": "error",
@@ -66,6 +67,7 @@ Configure it in `package.json`.
 - `compose-simplification` - Detects when a function that has the same behavior already exists
 - `cond-simplification` - Forbids using `cond` when `ifElse`, `either` or `both` fits
 - `either-simplification` - Suggests transforming negated `either` conditions on negated `both`
+- `eq-by-simplification` - Forbids `eqBy(prop(_))` and suggests `eqProps`
 - `filter-simplification` - Forbids using negated `filter` and suggests `reject`
 - `if-else-simplification` - Suggests `when` and `unless` when it is possible to replace
 - `map-simplification` - Forbids `map(prop(_))` and suggests `pluck`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ramda",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "ESLint rules for use with Ramda",
   "license": "MIT",
   "keywords": [

--- a/rules/map-simplification.js
+++ b/rules/map-simplification.js
@@ -12,8 +12,14 @@ const create = context => ({
             arguments: R.both(
                 R.propSatisfies(R.lt(0), 'length'),
                 R.propSatisfies(R.either(
-                    isCalling({ name: 'prop' }),
-                    isCalling({ name: 'pickAll' })
+                    isCalling({
+                        name: 'prop',
+                        arguments: R.propEq('length', 1)
+                    }),
+                    isCalling({
+                        name: 'pickAll',
+                        arguments: R.propEq('length', 1)
+                    })
                 ), 0)
             )
         });

--- a/test/map-simplification.js
+++ b/test/map-simplification.js
@@ -28,7 +28,9 @@ ruleTester.run('map-simplification', rule, {
         'map(doubleMe, [1, 2, 3])',
         'R.map(transformer, list)',
         'R.map(R.inc, [1, 2, 3])',
-        'project([\'name\', \'age\'])'
+        'project([\'name\', \'age\'])',
+        'map(prop(__, {}))',
+        'map(pickAll(__, items))'
     ],
     invalid: [
         {


### PR DESCRIPTION
This pull-request fixes a bug where `map(prop(__, obj))` was being incorrectly caught by the linter.
It also bumps the version to publish with the previous 2 rules and adds missing `eq-by-simplification` to `README.md`.