### PR TITLE
Add prefer-complement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Configure it in `package.json`.
       "ramda/no-redundant-not": "error",
       "ramda/no-redundant-or": "error",
       "ramda/pipe-simplification": "error",
+      "ramda/prefer-complement": "error",
       "ramda/prefer-ramda-boolean": "error",
       "ramda/prop-satisfies-simplification": "error",
       "ramda/reduce-simplification": "error",
@@ -76,6 +77,7 @@ Configure it in `package.json`.
 - `no-redundant-not` - Forbids `not` with 1 parameter in favor of `!`
 - `no-redundant-or` - Forbids `or` with 2 parameters in favor of `||`
 - `pipe-simplification` - Detects when a function that has the same behavior already exists
+- `prefer-complement` - Enforces using `complement` instead of compositions using `not`
 - `prefer-ramda-boolean` - Enforces using `R.T` and `R.F` instead of explicit functions
 - `prop-satisfies-simplification` - Detects when can replace `propSatisfies` by more simple functions
 - `reduce-simplification` - Detects when can replace `reduce` by `sum` or `product`

--- a/rules/prefer-complement.js
+++ b/rules/prefer-complement.js
@@ -1,0 +1,57 @@
+'use strict';
+const R = require('ramda');
+const ast = require('../ast-helper');
+
+const isCalling = ast.isCalling;
+const isRamdaMethod = ast.isRamdaMethod;
+const getName = ast.getName;
+
+const create = context => ({
+    CallExpression(node) {
+        const matchCompose = isCalling({
+            name: 'compose',
+            arguments: R.both(
+              R.propEq('length', 2),
+              R.where({
+                  0: isRamdaMethod('not'),
+              })
+            )
+        });
+
+        const matchPipe = isCalling({
+            name: 'pipe',
+            arguments: R.both(
+              R.propEq('length', 2),
+              R.where({
+                  1: isRamdaMethod('not'),
+              })
+            )
+        });
+
+        if (matchCompose(node)) {
+            const fn = getName(node.arguments[1]);
+            context.report({
+                node,
+                message: `Instead of \`compose(not, ${fn})\`, prefer \`complement(${fn})\``
+            });
+        }
+
+        if (matchPipe(node)) {
+            const fn = getName(node.arguments[0]);
+            context.report({
+                node,
+                message: `Instead of \`pipe(${fn}, not)\`, prefer \`complement(${fn})\``
+            });
+        }
+    }
+});
+
+module.exports = {
+    create,
+    meta: {
+        docs: {
+            description: 'Enforces using `complement` instead of compositions using `not`',
+            recommended: 'error'
+        }
+    }
+};

--- a/rules/prefer-complement.js
+++ b/rules/prefer-complement.js
@@ -51,7 +51,7 @@ module.exports = {
     meta: {
         docs: {
             description: 'Enforces using `complement` instead of compositions using `not`',
-            recommended: 'error'
+            recommended: 'off'
         }
     }
 };

--- a/test/prefer-complement.js
+++ b/test/prefer-complement.js
@@ -1,0 +1,53 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-complement';
+
+const ruleTester = avaRuleTester(test, {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        sourceType: 'module'
+    }
+});
+
+const instead = (composition, fn) => (composition === 'compose' ? `compose(not, ${fn})` : `pipe(${fn}, not)`);
+
+const error = (composition, fn) => ({
+  ruleId: 'prefer-complement',
+  message: `Instead of \`${instead(composition, fn)}\`, prefer \`complement(${fn})\``
+});
+
+ruleTester.run('prefer-complement', rule, {
+    valid: [
+        'complement(isEmpty)',
+        'complement(isNil)',
+        'propSatisfies(complement(isNil))',
+    ],
+    invalid: [
+        {
+            code: 'compose(not, isEmpty)',
+            errors: [error('compose', 'isEmpty')]
+        },
+        {
+            code: 'pipe(isEmpty, not)',
+            errors: [error('pipe', 'isEmpty')]
+        },
+        {
+            code: 'compose(not, isNil)',
+            errors: [error('compose', 'isNil')]
+        },
+        {
+            code: 'pipe(isNil, not)',
+            errors: [error('pipe', 'isNil')]
+        },
+        {
+            code: 'propSatisfies(compose(not, isNil))',
+            errors: [error('compose', 'isNil')]
+        },
+        {
+            code: 'propSatisfies(pipe(isNil, not))',
+            errors: [error('pipe', 'isNil')]
+        }
+    ]
+});

--- a/test/prefer-complement.js
+++ b/test/prefer-complement.js
@@ -23,6 +23,12 @@ ruleTester.run('prefer-complement', rule, {
         'complement(isEmpty)',
         'complement(isNil)',
         'propSatisfies(complement(isNil))',
+        'compose(foo, bar)',
+        'pipe(bar, foo)',
+        'compose(foo, not, bar)',
+        'compose(not, foo, bar)',
+        'pipe(bar, not, foo)',
+        'pipe(bar, foo, not)'
     ],
     invalid: [
         {
@@ -40,6 +46,14 @@ ruleTester.run('prefer-complement', rule, {
         {
             code: 'pipe(isNil, not)',
             errors: [error('pipe', 'isNil')]
+        },
+        {
+            code: 'compose(not, foo)',
+            errors: [error('compose', 'foo')]
+        },
+        {
+            code: 'pipe(foo, not)',
+            errors: [error('pipe', 'foo')]
         },
         {
             code: 'propSatisfies(compose(not, isNil))',


### PR DESCRIPTION
This pull request adds the `prefer-complement` rule.

It suggests using `complement(_)` instead of `compose(not, _)` or `pipe(_, not)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramda/eslint-plugin-ramda/13)
<!-- Reviewable:end -->
