### PR TITLE
Simplify and fix error reporting for prefer-complement

### DIFF
--- a/rules/prefer-complement.js
+++ b/rules/prefer-complement.js
@@ -4,43 +4,40 @@ const ast = require('../ast-helper');
 
 const isCalling = ast.isCalling;
 const isRamdaMethod = ast.isRamdaMethod;
-const getName = ast.getName;
 
 const create = context => ({
     CallExpression(node) {
         const matchCompose = isCalling({
             name: 'compose',
             arguments: R.both(
-              R.propEq('length', 2),
-              R.where({
-                  0: isRamdaMethod('not'),
-              })
+                R.propEq('length', 2),
+                R.where({
+                    0: isRamdaMethod('not'),
+                })
             )
         });
 
         const matchPipe = isCalling({
             name: 'pipe',
             arguments: R.both(
-              R.propEq('length', 2),
-              R.where({
-                  1: isRamdaMethod('not'),
-              })
+                R.propEq('length', 2),
+                R.where({
+                    1: isRamdaMethod('not'),
+                })
             )
         });
 
         if (matchCompose(node)) {
-            const fn = getName(node.arguments[1]);
             context.report({
                 node,
-                message: `Instead of \`compose(not, ${fn})\`, prefer \`complement(${fn})\``
+                message: `Instead of \`compose(not, ...)\`, prefer \`complement(...)\``
             });
         }
 
         if (matchPipe(node)) {
-            const fn = getName(node.arguments[0]);
             context.report({
                 node,
-                message: `Instead of \`pipe(${fn}, not)\`, prefer \`complement(${fn})\``
+                message: `Instead of \`pipe(..., not)\`, prefer \`complement(...)\``
             });
         }
     }

--- a/test/prefer-complement.js
+++ b/test/prefer-complement.js
@@ -11,11 +11,14 @@ const ruleTester = avaRuleTester(test, {
     }
 });
 
-const instead = (composition, fn) => (composition === 'compose' ? `compose(not, ${fn})` : `pipe(${fn}, not)`);
+const instead = {
+    compose: 'compose(not, ...)',
+    pipe: 'pipe(..., not)'
+};
 
-const error = (composition, fn) => ({
-  ruleId: 'prefer-complement',
-  message: `Instead of \`${instead(composition, fn)}\`, prefer \`complement(${fn})\``
+const error = composition => ({
+    ruleId: 'prefer-complement',
+    message: `Instead of \`${instead[composition]}\`, prefer \`complement(...)\``
 });
 
 ruleTester.run('prefer-complement', rule, {
@@ -33,35 +36,59 @@ ruleTester.run('prefer-complement', rule, {
     invalid: [
         {
             code: 'compose(not, isEmpty)',
-            errors: [error('compose', 'isEmpty')]
+            errors: [error('compose')]
+        },
+        {
+            code: 'compose(not, xs => xs.length)',
+            errors: [error('compose')]
         },
         {
             code: 'pipe(isEmpty, not)',
-            errors: [error('pipe', 'isEmpty')]
+            errors: [error('pipe')]
+        },
+        {
+            code: 'pipe(function (xs) { return xs.length === 0; }, not)',
+            errors: [error('pipe')]
         },
         {
             code: 'compose(not, isNil)',
-            errors: [error('compose', 'isNil')]
+            errors: [error('compose')]
+        },
+        {
+            code: 'compose(not, R.isNil)',
+            errors: [error('compose')]
         },
         {
             code: 'pipe(isNil, not)',
-            errors: [error('pipe', 'isNil')]
+            errors: [error('pipe')]
+        },
+        {
+            code: 'pipe(R.isNil, not)',
+            errors: [error('pipe')]
         },
         {
             code: 'compose(not, foo)',
-            errors: [error('compose', 'foo')]
+            errors: [error('compose')]
+        },
+        {
+            code: 'compose(not, foo(bar))',
+            errors: [error('compose')]
         },
         {
             code: 'pipe(foo, not)',
-            errors: [error('pipe', 'foo')]
+            errors: [error('pipe')]
+        },
+        {
+            code: 'pipe(foo(bar), not)',
+            errors: [error('pipe')]
         },
         {
             code: 'propSatisfies(compose(not, isNil))',
-            errors: [error('compose', 'isNil')]
+            errors: [error('compose')]
         },
         {
             code: 'propSatisfies(pipe(isNil, not))',
-            errors: [error('pipe', 'isNil')]
+            errors: [error('pipe')]
         }
     ]
 });


### PR DESCRIPTION
This PR simplifies and fixes the error reporting for `prefer-complement`.

Cases with arrow functions, anonymous function expressions, member expressions and call expressions are not covered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramda/eslint-plugin-ramda/18)
<!-- Reviewable:end -->
