### PR TITLE
Update to Node v6 compatibility (#22)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
   "plugins": ["node"],
   "rules": {
     "node/exports-style": ["error", "module.exports"],
+    "node/no-deprecated-api": "error",
     "node/no-extraneous-import": "error",
     "node/no-extraneous-require": "error",
     "node/no-missing-import": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,13 +3,15 @@
     "ecmaVersion": 6,
     "sourceType": "module"
   },
+  "plugins": ["node"],
   "rules": {
-    "no-restricted-syntax": [
-      "error",
-      {
-        "selector": ":matches(ArrayPattern, ObjectPattern)",
-        "message": "Using destructuring assignment breaks compatibilization with Node v4"
-      }
-    ]
+    "node/exports-style": ["error", "module.exports"],
+    "node/no-extraneous-import": "error",
+    "node/no-extraneous-require": "error",
+    "node/no-missing-import": "error",
+    "node/no-missing-require": "error",
+    "node/no-unsupported-features/es-builtins": "error",
+    "node/no-unsupported-features/es-syntax": "error",
+    "node/no-unsupported-features/node-builtins": "error"
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
   - '9'
   - '10'
   - '11'
-  - '12'
 
 install:
   - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: node_js
 node_js:
-  - '4'
-  - '5'
   - '6'
   - '7'
   - '8'
   - '9'
+  - '10'
+  - '11'
+  - '12'
 
 install:
   - yarn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ramda",
-  "version": "2.5.1",
+  "version": "3.0.0-beta.0",
   "description": "ESLint rules for use with Ramda",
   "license": "MIT",
   "keywords": [
@@ -28,8 +28,9 @@
   "devDependencies": {
     "ava": "^0.23.0",
     "codecov": "^3.0.0",
-    "eslint": "~4.11.0",
+    "eslint": "~4.19.0",
     "eslint-ava-rule-tester": "^2.0.2",
+    "eslint-plugin-node": "^8.0.0",
     "nyc": "^11.3.0"
   },
   "repository": {
@@ -37,7 +38,7 @@
     "url": "git://github.com/ramda/eslint-plugin-ramda.git"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "files": [
     "index.js",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "node/no-unsupported-features/es-syntax": "off"
+  }
+}


### PR DESCRIPTION
This commit bumps the compatibility for the plugin to Node 6, the
current Maintenance LTS.  Node v4 is [no longer supported][node], so
it's not that big of a stretch to do this.  That said, it *does*
explicitly break API compatibility, so the Major version had to go up by
one (plus a beta tag so it isn't just installed by default).

[node]: https://github.com/nodejs/Release#readme

Signed-off-by: Jonathan Sifuentes <jayands.dev@gmail.com>