### PR TITLE
Rule composition preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Configure it in `package.json`.
       "ramda/complement-simplification": "error",
       "ramda/compose-pipe-style": "error",
       "ramda/compose-simplification": "error",
+      "ramda/composition-preference": ["error", {
+        "singleLine": "pipe | compose",
+        "multiline": "pipe | compose",
+      }],
       "ramda/cond-simplification": "error",
       "ramda/either-simplification": "error",
       "ramda/eq-by-simplification": "error",
@@ -67,6 +71,7 @@ Configure it in `package.json`.
 - `complement-simplification` - Forbids confusing `complement`, suggesting a better one
 - `compose-pipe-style` - Enforces `compose` for single line expression and `pipe` for multiline
 - `compose-simplification` - Detects when a function that has the same behavior already exists
+- `composition-preference` - Enforces prefered function composition for single and multiline expressions
 - `cond-simplification` - Forbids using `cond` when `ifElse`, `either` or `both` fits
 - `either-simplification` - Suggests transforming negated `either` conditions on negated `both`
 - `eq-by-simplification` - Forbids `eqBy(prop(_))` and suggests `eqProps`

--- a/ast-helper.js
+++ b/ast-helper.js
@@ -39,7 +39,137 @@ const isBooleanLiteral = R.both(
     R.propSatisfies(R.is(Boolean), 'value')
 );
 
-exports.isRamdaMethod = isRamdaMethod;
-exports.isCalling = isCalling;
-exports.getName = getName;
-exports.isBooleanLiteral = isBooleanLiteral;
+// :: Node -> Boolean
+const isLineComment = R.propEq('type', 'Line');
+// :: Node -> Boolean
+const isBlockComment = R.propEq('type', 'Block');
+// :: Node -> Boolean
+const isComment = R.anyPass([isLineComment, isBlockComment]);
+// :: Node -> Number
+const endLn = R.path(['loc', 'end', 'line']);
+// :: Node -> Boolean
+const notEmpty = R.complement(R.isEmpty);
+// :: Node -> [ Number, Number ]
+const identifierRange = R.ifElse(
+    R.propEq('type', 'Identifier'),
+    R.prop('range'),
+    R.path(['property', 'range'])
+);
+
+// :: String, Number -> String
+const repeatChar = (char, n) => R.join('', R.times(() => char, R.max(0, n)));
+
+// :: SourceCode -> Array<ASTNodes> -> String
+const joinNodes = sourceCode =>
+    R.pipe(
+        R.reduce((acc, curr) => {
+            if (R.is(String, curr)) {
+                return R.evolve({
+                    text: R.flip(R.concat)(curr),
+                })(acc);
+            }
+
+            const { end, start } = curr.loc;
+            const text = sourceCode.getText(curr);
+
+            if (!acc) return { text, end };
+
+            if (acc.end.line === start.line) {
+                const commaLength = isComment(curr) && sourceCode.getTokenBefore(curr).value === ',' ? 1 : 0;
+                const strBetween = repeatChar(' ', start.column - acc.end.column - commaLength);
+
+                return {
+                    text: acc.text + strBetween + text,
+                    end,
+                };
+            }
+
+            const strBetween = repeatChar('\n', start.line - acc.end.line) + repeatChar(' ', start.column);
+                
+            return {
+                text: acc.text + strBetween + text,
+                end,
+            };
+        }, null),
+        R.prop('text')
+    );
+
+// :: SourceCode, ASTArgumentNode, Array<ASTNodes> -> [ [ Number, Number ], String ]
+const replaceArgument = (sourceCode, argToReplace, nodes) => {
+    /**
+     * In case if last node is comment we could potentially comment out comma that is needed.
+     * To resolve that we are adding it before comment and removing the one after comment
+     */
+    const nextToken = sourceCode.getTokenAfter(argToReplace);
+    if (isComment(R.last(nodes)) && nextToken.value === ',') {
+        const nodesWithComma = R.insert(nodes.length - 1, ',', nodes);
+
+        return [
+            [argToReplace.start, nextToken.end],
+            joinNodes(sourceCode)(nodesWithComma),
+        ];
+    }
+
+    return [
+        [argToReplace.start, argToReplace.end],
+        joinNodes(sourceCode)(nodes),
+    ];
+};
+
+// :: SourceCode, Array<ASTNodes> -> [ Number, Number ]
+const commentsRanges = (sourceCode, node) => sourceCode.getCommentsInside(node).map(comment => {
+    const prevToken = sourceCode.getTokenBefore(comment);
+    const nextToken = sourceCode.getTokenAfter(comment);
+
+    // basic [comment.start, comment.end] will leave whitespaces
+    if (endLn(comment) === endLn(prevToken)) {
+        return [
+            prevToken.end,
+            comment.end
+        ];
+    }
+
+    return [
+        comment.start,
+        nextToken.start
+    ];
+});
+
+// :: SourceCode -> Array<ASTNodes> -> Array<Array<ASTNodes>>
+const getArgumentsWithComments = sourceCode => R.pipe(
+    R.map(current => [
+        ...sourceCode.getCommentsBefore(current),
+        current,
+        ...sourceCode.getCommentsAfter(current),
+    ]),
+    R.reduce((acc, curr) => {
+        if (notEmpty(acc)) {
+            /**
+             * if you have comment at the end of line, eslint usually assagning that
+             * comment to next token. That will move affected comments to their owners
+             */
+            const lastAcc = R.last(acc);
+            const currHead = R.head(curr);
+            if (isComment(currHead) && endLn(currHead) === endLn(R.last(lastAcc))) {
+                return [
+                    ...R.init(acc),
+                    [...lastAcc, currHead],
+                    R.tail(curr),
+                ];
+            }
+        }
+
+        return [...acc, curr];
+    }, [])
+);
+
+module.exports = {
+    isRamdaMethod,
+    isCalling,
+    getName,
+    isBooleanLiteral,
+    commentsRanges,
+    identifierRange,
+    replaceArgument,
+    getArgumentsWithComments,
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "create-eslint-index": "^1.0.0",
+    "dedent": "^0.7.0",
     "ramda": "0.25.0",
     "req-all": "^2.0.0"
   },

--- a/rules/composition-preference.js
+++ b/rules/composition-preference.js
@@ -1,0 +1,106 @@
+'use strict';
+const R = require('ramda');
+const {
+    isCalling,
+    commentsRanges,
+    identifierRange,
+    replaceArgument,
+    getArgumentsWithComments,
+} = require('../ast-helper');
+
+const startLine = R.path(['loc', 'start', 'line']);
+const endLine = R.path(['loc', 'end', 'line']);
+const isSingleLine = R.converge(R.equals, [startLine, endLine]);
+
+const matchCompose = isCalling({
+    name: 'compose',
+});
+
+const matchPipe = isCalling({
+    name: 'pipe',
+});
+
+const makeMsg = (is, should, when) =>
+    `Prefer \`${should}\` over \`${is}\` for ${when} expression`;
+
+const create = context => ({
+    CallExpression(node) {
+        const isPipe = matchPipe(node);
+        const isCompose = matchCompose(node);
+
+        if (isPipe || isCompose) {
+            const {
+                singleLine = 'compose',
+                multiline = 'pipe',
+            } = R.pathOr({}, ['options', 0], context);
+            const sourceCode = context.getSourceCode();
+
+            const fix = toMethod => fixer => {
+                const args = R.reverse(getArgumentsWithComments(sourceCode)(node.arguments));
+
+                return [
+                    fixer.replaceTextRange(identifierRange(node.callee), toMethod),
+                    ...R.map(fixer.removeRange, commentsRanges(sourceCode, node)),
+                    ...node.arguments
+                        .map((token, i) => replaceArgument(sourceCode, token, args[i]))
+                        .map(x => fixer.replaceTextRange(...x)),
+                ];
+            };
+
+            if (isSingleLine(node)) {
+                if (singleLine === 'compose' && isPipe) {
+                    context.report({
+                        node,
+                        message: makeMsg('pipe', 'compose', 'single line'),
+                        fix: fix('compose'),
+                    });
+                } else if (singleLine === 'pipe' && isCompose) {
+                    context.report({
+                        node,
+                        message: makeMsg('compose', 'pipe', 'single line'),
+                        fix: fix('pipe'),
+                    });
+                }
+            } else {
+                if (multiline === 'compose' && isPipe) {
+                    context.report({
+                        node,
+                        message: makeMsg('pipe', 'compose', 'multiline'),
+                        fix: fix('compose'),
+                    });
+                } else if (multiline === 'pipe' && isCompose) {
+                    context.report({
+                        node,
+                        message: makeMsg('compose', 'pipe', 'multiline'),
+                        fix: fix('pipe'),
+                    });
+                }
+            }
+        }
+    }
+});
+
+const compositionFn = ['compose', 'pipe'];
+const schema = [{
+    type: 'object',
+    properties: {
+        singleLine: {
+            enum: compositionFn,
+        },
+        multiline: {
+            enum: compositionFn,
+        },
+    },
+}];
+
+module.exports = {
+    create,
+    schema,
+    meta: {
+        docs: {
+            description: 'Enforces prefered function composition for single and multiline expressions',
+            recommended: 'off',
+        },
+        fixable: 'code',
+    }
+};

--- a/test/composition-preference.js
+++ b/test/composition-preference.js
@@ -1,0 +1,211 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import dedent from 'dedent';
+import rule from '../rules/composition-preference';
+
+const ruleTester = avaRuleTester(test, {
+    env: {
+        es6: true,
+    },
+    parserOptions: {
+        sourceType: 'module',
+    },
+});
+
+const error = {
+    pipeSingle: {
+        ruleId: 'composition-preference',
+        message: 'Prefer `pipe` over `compose` for single line expression',
+    },
+    composeSingle: {
+        ruleId: 'composition-preference',
+        message: 'Prefer `compose` over `pipe` for single line expression',
+    },
+    pipeMulti: {
+        ruleId: 'composition-preference',
+        message: 'Prefer `pipe` over `compose` for multiline expression',
+    },
+    composeMulti: {
+        ruleId: 'composition-preference',
+        message: 'Prefer `compose` over `pipe` for multiline expression',
+    },
+};
+
+ruleTester.run('composition-preference', rule, {
+    valid: [
+        {
+            code: 'R.compose(e, d, c, b, a => a * 2)',
+            options: [{ singleLine: 'compose' }],
+        },
+        {
+            code: 'compose(c, b)',
+            options: [{ singleLine: 'compose' }],
+        },
+        {
+            code: 'R.pipe(a => a * 2, b, c)',
+            options: [{ singleLine: 'pipe' }],
+        },
+        {
+            code: 'pipe(a => a * 2, b)',
+            options: [{ singleLine: 'pipe' }],
+        },
+        {
+            code: dedent`
+                R.compose(
+                    d, // sample
+                    c,
+                    b => b / 10,
+                    a => a * 2
+                )
+            `,
+            options: [{ multiline: 'compose' }],
+        },
+        {
+            code: dedent`
+                compose(
+                    anotherFn,
+                    a => a * 2
+                )
+            `,
+            options: [{ multiline: 'compose' }],
+        },
+        {
+            code: dedent`
+                R.pipe(
+                    a => a * 2,
+                    b => b / 10,
+                    c,
+                    d // sample
+                )
+            `,
+            options: [{ multiline: 'pipe' }],
+        },
+        {
+            code: dedent`
+                pipe(
+                    a => a * 2,
+                    anotherFn
+                )
+            `,
+            options: [{ multiline: 'pipe' }],
+        },
+        {
+            code: 'add(1, pipe(a => a * 2, anotherFn))',
+            options: [{ singleLine: 'pipe' }],
+        },
+    ],
+    invalid: [
+        {
+            code: 'compose(c, b, a)',
+            options: [{ singleLine: 'pipe' }],
+            errors: [error.pipeSingle],
+            output: 'pipe(a, b, c)',
+        },
+        {
+            code: 'R.compose(e, d, c, b, a => a * 2)',
+            options: [{ singleLine: 'pipe' }],
+            errors: [error.pipeSingle],
+            output: 'R.pipe(a => a * 2, b, c, d, e)',
+        },
+        {
+            code: 'pipe(a, b, c)',
+            options: [{ singleLine: 'compose' }],
+            errors: [error.composeSingle],
+            output: 'compose(c, b, a)',
+        },
+        {
+            code: 'R.pipe(a => a * 2, b, c, d, e)',
+            options: [{ singleLine: 'compose' }],
+            errors: [error.composeSingle],
+            output: 'R.compose(e, d, c, b, a => a * 2)',
+        },
+        {
+            code: dedent`
+                R.compose(
+                    d, // sample
+                    c,
+                    // comment for b => b /10
+                    b => b / 10,
+                    /**
+                     * Some explanation
+                     */
+                    a => a * 2
+                )
+            `,
+            options: [{ multiline: 'pipe' }],
+            errors: [error.pipeMulti],
+            output: dedent`
+                R.pipe(
+                    /**
+                     * Some explanation
+                     */
+                    a => a * 2,
+                    // comment for b => b /10
+                    b => b / 10,
+                    c,
+                    d // sample
+                )
+            `,
+        },
+        {
+            code: dedent`
+                compose(
+                    anotherFn, /* comment b */
+                    a => a * 2 // comment a
+                )
+            `,
+            options: [{ multiline: 'pipe' }],
+            errors: [error.pipeMulti],
+            output: dedent`
+                pipe(
+                    a => a * 2, // comment a
+                    anotherFn /* comment b */
+                )
+            `,
+        },
+        {
+            code: dedent`
+                R.pipe(
+                    /**
+                     * Some explanation
+                     */
+                    a => a * 2,
+                    // comment for b => b /10
+                    b => b / 10,
+                    c,
+                    d // sample
+                )
+            `,
+            options: [{ multiline: 'compose' }],
+            errors: [error.composeMulti],
+            output: dedent`
+                R.compose(
+                    d, // sample
+                    c,
+                    // comment for b => b /10
+                    b => b / 10,
+                    /**
+                     * Some explanation
+                     */
+                    a => a * 2
+                )
+            `,
+        },
+        {
+            code: dedent`
+                pipe(
+                    a => a * 2, // comment a
+                    anotherFn /* comment b */
+                )
+            `,
+            options: [{ multiline: 'compose' }],
+            errors: [error.composeMulti],
+            output: dedent`
+                compose(
+                    anotherFn, /* comment b */
+                    a => a * 2 // comment a
+                )
+            `,
+        },
+    ]
+});


### PR DESCRIPTION
Add `composition-preference` rule.

This rule is similar to `compose-pipe-style` but allows for some flexibility - you can specify desired style for single line and multiline expressions.
It also contains fixer that flips order of arguments and changes name of function. If any comment exist inside pipe/compose prior to auto-fix it'll do its best to make it stay in proper place.

