### PR TITLE
Don't declare and <-> or as complements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ramda",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.1-beta.1",
   "description": "ESLint rules for use with Ramda",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ramda",
-  "version": "3.0.1-beta.1",
+  "version": "3.0.0-beta.1",
   "description": "ESLint rules for use with Ramda",
   "license": "MIT",
   "keywords": [

--- a/rules/complement-simplification.js
+++ b/rules/complement-simplification.js
@@ -10,7 +10,9 @@ const names = {
     or: 'and',
     and: 'or',
     T: 'F',
-    F: 'T'
+    F: 'T',
+    lte: 'gt',
+    gte: 'lt'
 };
 
 const create = context => ({

--- a/rules/complement-simplification.js
+++ b/rules/complement-simplification.js
@@ -7,12 +7,8 @@ const isRamdaMethod = ast.isRamdaMethod;
 const getName = ast.getName;
 
 const names = {
-    or: 'and',
-    and: 'or',
     T: 'F',
-    F: 'T',
-    lte: 'gt',
-    gte: 'lt'
+    F: 'T'
 };
 
 const create = context => ({

--- a/test/complement-simplification.js
+++ b/test/complement-simplification.js
@@ -46,6 +46,14 @@ ruleTester.run('complement-simplification', rule, {
         {
             code: 'R.complement(or)',
             errors: [error('or', 'and')]
+        },
+        {
+            code: 'complement(lte)',
+            errors: [error('lte', 'gt')]
+        },
+        {
+            code: 'complement(gte)',
+            errors: [error('gte', 'lt')]
         }
     ]
 });

--- a/test/complement-simplification.js
+++ b/test/complement-simplification.js
@@ -19,6 +19,8 @@ const error = (from, to) => ({
 ruleTester.run('complement-simplification', rule, {
     valid: [
         'complement(equals)',
+        'complement(and)',
+        'complement(or)',
         'complement(odd())',
         'R.complement(equals)'
     ],
@@ -32,28 +34,8 @@ ruleTester.run('complement-simplification', rule, {
             errors: [error('F', 'T')]
         },
         {
-            code: 'complement(or)',
-            errors: [error('or', 'and')]
-        },
-        {
-            code: 'complement(and)',
-            errors: [error('and', 'or')]
-        },
-        {
             code: 'R.complement(R.T)',
             errors: [error('T', 'F')]
-        },
-        {
-            code: 'R.complement(or)',
-            errors: [error('or', 'and')]
-        },
-        {
-            code: 'complement(lte)',
-            errors: [error('lte', 'gt')]
-        },
-        {
-            code: 'complement(gte)',
-            errors: [error('gte', 'lt')]
         }
     ]
 });


### PR DESCRIPTION
I tried to add `nand` as function to ramda-adjunct, see https://github.com/char0n/ramda-adjunct/issues/237. When I tried to do that, eslint-plugin-ramda complaint about `complement(and)` being replaceable by `or`.

This is strictly not true for one case:

```
R.or(false, false) -> false
R.complement(R.and(false, false)) -> true
```

Am I missing something?
